### PR TITLE
Fixes for cross-platform use

### DIFF
--- a/pacman_game.py
+++ b/pacman_game.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import pygame
 import sys
 import random


### PR DESCRIPTION
When running from a CLI in a unix-like environment, it's helpful for the main entry point to have the execute bit set and to have a shebang line. The x-bit is invisible in Windows, and Windows treats the shebang as a comment, so these two things do no harm there. In a Unix-like environment, it makes it possibe to run `./pacman_game.py` without needing to prefix it with `python`.